### PR TITLE
docs: add bitcoin and the graph to network coverage

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -16,6 +16,8 @@ Our coverage so far includes ZCash, Aleo, Algorand, and the XRP Ledger. More are
 | [ZCash]            | 💚               | 💚            | 💚              | 💚                 | 💚                    | 💚                       |
 | [XRP Ledger]       | 💚               | 💚            | 💚              | 💚                 | ❌                    | 💚                       |
 | [Algorand]         | 💚               | 💚            | ❌              | 💚                 | ❌                    | 💚                       |
+| [Bitcoin]         | ❌               | 💚            | ❌              | ❌                 | ❌                    | ❌                       |
+| [The Graph]         | ❌               | 💚            | ❌              | ❌                 | ❌                    | ❌                       |
 
 [Zcash]: https://github.com/runziggurat/zcash
 [XRP Ledger]: https://github.com/runziggurat/xrpl


### PR DESCRIPTION
Adds bitcoin and the graph fuzzing to the coverage chart